### PR TITLE
Added Multithreading and Wordlist Support

### DIFF
--- a/awsscrape.go
+++ b/awsscrape.go
@@ -55,7 +55,12 @@ func main() {
 			log.Println("Error reading wordlist file:", err)
 			return
 		}
-		keywordList = strings.Split(string(keywords), "\n")
+		lines := strings.Split(string(keywords), "\n")
+		for _, line := range lines {
+			if len(strings.TrimSpace(line)) > 0 {
+				keywordList = append(keywordList, line)
+			}
+		}
 	} else {
 		keywordList = []string{keyword}
 	}


### PR DESCRIPTION
This pull request adds a number of features, including:

- Wordlist support, by using -w|-wordlist. Existing keyword support is still available
- Randomize to toggle randomizing the order in which IP addresses in the range will be checked
- Threads (default 4) to specify the number of threads to use
- Timeout (default 1) to specify the number of seconds for a timeout
- Output (filename) to specify a file to output to
- Verbose by using -verbose|-v to toggle verbosity

Verbose mode looks like the following:

![image](https://user-images.githubusercontent.com/886344/226226648-a1682ba1-41a6-43c0-bfc8-f2f8a307c306.png)

If the number of items in a wordlist exceeds 20, then this mode will instead tell you how many items it checked instead of outputting them all.

I've also added a series of error handling steps. Further improvements could be made standardizing outputs to allow better grepping of results, as well as applying that to the error messages I've included. If you find this pull request useful, I'd be happy to explore doing that to increase the utility of this in a bug bounty toolchain.